### PR TITLE
owlet-feat: adds email confirmation and link to unsubscribe

### DIFF
--- a/resources/public/activity-email.html
+++ b/resources/public/activity-email.html
@@ -32,5 +32,8 @@
       </a>
       {% endfor %}
     </div>
+    <p style="text-align:center,font-size:0.5rem">
+      <a href="http://owlet.codefordenver.org/#/unsubscribe">Unsubscribe</a>
+    </p>
   </body>
 </html>

--- a/resources/public/confirm-email.html
+++ b/resources/public/confirm-email.html
@@ -1,0 +1,12 @@
+<html style="font-size: 14px">
+  <head>
+    <link href='https://fonts.googleapis.com/css?family=Rubik:300,400,700' rel='stylesheet' type='text/css'>
+  </head>
+  <body style="font: 100% 'Rubik', sans-serif;font-size: 1.5rem">
+    <h3>OWLET | New Activities Subscription</h1>
+    <p>Please confirm your subscription by clicking this link.</p>
+    <p>If you received this email by mistake, simply delete it. You won't be subscribed if you don't click the confirmation link above.</p>
+    <p>For questions about this list, please contact:<br>
+       <a href="mailto:owlet@mmmanyfold.com">owlet@mmmanyfold.com</a></p>
+  </body>
+</html>

--- a/resources/public/confirm-email.html
+++ b/resources/public/confirm-email.html
@@ -2,7 +2,7 @@
   <head>
     <link href='https://fonts.googleapis.com/css?family=Rubik:300,400,700' rel='stylesheet' type='text/css'>
   </head>
-  <body style="font: 100% 'Rubik', sans-serif;font-size: 1.5rem">
+  <body style="font: 100% 'Rubik', sans-serif;font-size: 1rem">
     <h3>OWLET | New Activities Subscription</h1>
     <p>Please confirm your subscription by <a href="{{url}}">clicking this link</a>.</p>
     <p>If you received this email by mistake, simply delete it. You won't be subscribed if you don't click the confirmation link above.</p>

--- a/resources/public/confirm-email.html
+++ b/resources/public/confirm-email.html
@@ -4,7 +4,7 @@
   </head>
   <body style="font: 100% 'Rubik', sans-serif;font-size: 1.5rem">
     <h3>OWLET | New Activities Subscription</h1>
-    <p>Please confirm your subscription by clicking this link.</p>
+    <p>Please confirm your subscription by <a href="{{url}}">clicking this link</a>.</p>
     <p>If you received this email by mistake, simply delete it. You won't be subscribed if you don't click the confirmation link above.</p>
     <p>For questions about this list, please contact:<br>
        <a href="mailto:owlet@mmmanyfold.com">owlet@mmmanyfold.com</a></p>

--- a/resources/public/confirm-email.html
+++ b/resources/public/confirm-email.html
@@ -4,8 +4,8 @@
   </head>
   <body style="font: 100% 'Rubik', sans-serif;font-size: 1rem">
     <h3>OWLET | New Activities Subscription</h1>
-    <p>Please confirm your subscription by <a href="{{url}}">clicking this link</a>.</p>
-    <p>If you received this email by mistake, simply delete it. You won't be subscribed if you don't click the confirmation link above.</p>
+    <p>Please confirm your {{un}}subscription by <a href="{{url}}">clicking this link</a>.</p>
+    <p>If you received this email by mistake, simply delete it. You won't be {{un}}subscribed if you don't click the confirmation link above.</p>
     <p>For questions about this list, please contact:<br>
        <a href="mailto:owlet@mmmanyfold.com">owlet@mmmanyfold.com</a></p>
   </body>

--- a/src/clj/mmmanyfold/routes/owlet.clj
+++ b/src/clj/mmmanyfold/routes/owlet.clj
@@ -204,6 +204,7 @@
              (= 1 (get-in payload [:sys :revision])))]
     (if is-new-activity?
       (let [{:keys [status body]} @(http/get subscribers-endpoint)]
+        ;TODO: normalize list of subscribers for this handler
         (if (= 200 status)
           (let [json (json/parse-string body true)
                 coll (remove nil? json)

--- a/src/clj/mmmanyfold/routes/owlet.clj
+++ b/src/clj/mmmanyfold/routes/owlet.clj
@@ -19,7 +19,7 @@
 (defonce OWLET-ACTIVITIES-3-DELIVERY-AUTH-TOKEN
          (System/getenv "OWLET_ACTIVITIES_3_DELIVERY_AUTH_TOKEN"))
 
-(def owlet-url "http://localhost:4000")
+(def owlet-url "http://owlet.codefordenver.org")
 
 (defn epoch [] (int (/ (System/currentTimeMillis) 1000)))
 
@@ -187,7 +187,7 @@
 
 (defn- send-confirmation-email [email id subscribing]
   "Sends confirmation email"
-  (let [url (format "http://localhost:3000/owlet/webhook/content/confirm?id=%1s" id)
+  (let [url (format "https://mmmanyfold-api.herokuapp.com/owlet/webhook/content/confirm?id=%1s" id)
         html (if (= subscribing true)
               (render-file "public/confirm-email.html" {:url url :un ""})
               (render-file "public/confirm-email.html" {:url url :un "un"}))
@@ -209,11 +209,11 @@
              (= 1 (get-in payload [:sys :revision])))]
     (if is-new-activity?
       (let [{:keys [status body]} @(http/get subscribers-endpoint)]
-        ;TODO: normalize list of subscribers for this handler
         (if (= 200 status)
           (let [json (json/parse-string body true)
-                coll (remove nil? json)
-                subscribers (clojure.string/join "," coll)]
+                users (map val json)
+                emails (for [user users :when (:confirmed user)] (:email user))
+                subscribers (clojure.string/join "," emails)]
             (let [space-id (get-in payload [:sys :space :sys :id])
                   asset-id (get-in payload [:fields :preview :en-US :sys :id])
                   {:keys [status body]} @(get-asset-by-id space-id asset-id)]


### PR DESCRIPTION
must merge with https://github.com/codefordenver/owlet-ui/pull/158

TODO:
- [x] update handle-unsubscribe
- [x] update handle-activity-publish
- [x] use subscriber id instead of email in confirmation url
- [x] use same email for subscribe & unsubscribe